### PR TITLE
ci: Fix the manual NuGet publishing workflow.

### DIFF
--- a/.github/workflows/manual_publish_nuget_pkg.yaml
+++ b/.github/workflows/manual_publish_nuget_pkg.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get current version
         id: current_version
         run: |
-          $currentVersion = (Select-Xml -Path src/OpenPolicyAgent.Ucast.Linq/OpenPolicyAgent.Ucast.Linq.csproj -XPath "//PackageVersion").Node.InnerText
+          $currentVersion = (Select-Xml -Path src/OpenPolicyAgent.Opa.AspNetCore/OpenPolicyAgent.Opa.AspNetCore.csproj -XPath "//PackageVersion").Node.InnerText
           echo "CURRENT_VERSION=$currentVersion" >> $env:GITHUB_OUTPUT
         shell: pwsh
 


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

The manual NuGet publishing workflow had a copy/pasta error from the file I borrowed from [ucast-linq](https://github.com/open-policy-agent/ucast-linq). This PR corrects it so that the scripts look in the proper directory for the project files.

### :athletic_shoe: How to test

 - Merge the PR. Run the workflow.

### :chains: Related Resources

